### PR TITLE
rust-server: Implement a disk metric for warn and interval mode.

### DIFF
--- a/rust-server/.env.example
+++ b/rust-server/.env.example
@@ -6,15 +6,17 @@ mode=warn
 
 
 # Interval mode settings, different system metrics [enabled/disabled]
-ram=enabled 
-cpu=enabled 
-cpu_average=enabled
-system_uptime=enabled
+ram=true
+cpu=true
+cpu_average=true
+system_uptime=true
+disk=true
 
 
 # Warn mode settings [IN PERCENTAGES]
-ram_limit=80%
-cpu_limit=50%
+ram_limit=10
+cpu_limit=5
+disk_limit=10
 
 
 # How often should the program run [in seconds], the higher the delay, the less system resources 

--- a/rust-server/src/logging/discord/parsers.rs
+++ b/rust-server/src/logging/discord/parsers.rs
@@ -25,6 +25,7 @@ mod tests {
             mode: ConfigMode::ConfigWarn {
                 cpu_limit: 0,
                 ram_limit: 0,
+                disk_limit: 0,
             },
             interval: 0,
             log_type: LogType::Discord,

--- a/rust-server/src/metrics/interval.rs
+++ b/rust-server/src/metrics/interval.rs
@@ -62,6 +62,7 @@ impl IntervalMetrics {
     }
 
 
+    // Check which metric is enabled and update it. 
     pub fn update_metrics(&mut self, system: &mut sysinfo::System) {
         system.refresh_all();
         

--- a/rust-server/src/metrics/mod.rs
+++ b/rust-server/src/metrics/mod.rs
@@ -1,3 +1,88 @@
+use sysinfo::{DiskExt};
+
+
 pub mod interval;
 pub mod warn;
 
+
+fn get_total_disk_space<T>(disks: &[T]) -> f64 where T: DiskExt {
+    let mut total_space = 0;
+
+    disks.iter().for_each(|disk| {
+        total_space += disk.get_total_space();
+    });
+
+    (total_space / 1_000_000) as f64
+}
+
+
+
+fn get_used_disk_space<T>(disks: &[T]) -> i64 where T: DiskExt {
+    let mut total_used = 0_i64;
+
+    disks.iter().for_each(|disk| {
+        total_used += ((disk.get_total_space() - disk.get_available_space())  / 1_000_000) as i64;
+    });
+
+    total_used
+}
+
+
+#[cfg(test)]
+mod tests {
+    use super::{get_total_disk_space, get_used_disk_space};
+    use sysinfo::{DiskExt, DiskType};
+    use std::ffi::OsStr;
+    use std::path::Path;
+
+    #[derive(Debug)]
+    struct MockedDisk { available: u64, total: u64 }
+
+    impl DiskExt for MockedDisk {
+        fn get_type(&self) -> DiskType { DiskType::HDD }
+        fn get_available_space(&self) -> u64 { self.available }
+        fn get_file_system(&self) -> &[u8] { &[2, 3, 6, 4] }
+        fn get_name(&self) -> &OsStr { OsStr::new("") }
+        fn get_mount_point(&self) -> &Path { Path::new("") }
+        fn get_total_space(&self) -> u64 { self.total }
+        fn refresh(&mut self) -> bool { true }
+    }
+
+
+    #[test]
+    fn get_used_disk_space_gets_used() {
+        let disks = [
+            MockedDisk {
+                available: 1_000_000_000, // 1 GB 
+                total: 5_000_000_000 // 5 GB
+            },
+
+            MockedDisk {
+                available: 450_000_000, // 450 MB
+                total: 2_000_000_000 // 2 GB
+            }
+        ];
+
+        let used_space = get_used_disk_space(&disks);
+        assert_eq!(used_space, ((5_000_000_000 - 1_000_000_000) + (2_000_000_000 - 450_000_000)) / 1000000);
+    }
+
+
+    #[test]
+    fn get_total_disk_space_gets_all_space() {
+        let disks = [
+            MockedDisk {
+                available: 1_000_000_000, // 1 GB 
+                total: 5_000_000_000 // 5 GB
+            },
+
+            MockedDisk {
+                available: 450_000_000, // 450 MB
+                total: 2_000_000_000 // 2 GB
+            }
+        ];
+
+        let total_space = get_total_disk_space(&disks);
+        assert_eq!(total_space, 7000.0);
+    }
+}

--- a/rust-server/src/metrics/warn.rs
+++ b/rust-server/src/metrics/warn.rs
@@ -94,7 +94,7 @@ impl WarnMetrics {
 // If it is, return the % of the metric that is used to the warn vector.
 fn above_limit(metric_limit: f64, total_metric: f64, used_metric: f64, metric_type: MetricType) -> Result<Warn, bool> {
     let used_percentage = (used_metric / total_metric) * 100.0;
-    println!("{}, {}, {}", total_metric, used_metric, used_percentage);
+
     if used_percentage > metric_limit {
         match metric_type {
             MetricType::RAM => Ok(Warn::HighRAM(used_percentage as f32)),


### PR DESCRIPTION
This commit introduces updates for the warn and interval modes, giving them the ability to log the current disk usage.

Closes #2 