### PR TITLE
rust-server: Implements a swap memory metric (#3)

### DIFF
--- a/env_setup.md
+++ b/env_setup.md
@@ -36,6 +36,7 @@ cpu=true
 cpu_average=false
 system_uptime=false
 disk=true
+swap=true
 ```
 
 <br />
@@ -47,6 +48,7 @@ When using the warn mode, you need to specify the following parameters (which wo
 ram_limit=10
 cpu_limit=67
 disk_limit=15
+swap_limit=20
 ```
 
 <br />

--- a/env_setup.md
+++ b/env_setup.md
@@ -43,7 +43,7 @@ swap=true
 <br />
 
 ## Warn Settings
-When using the warn mode, you need to specify the following parameters (which works in integer percentages):
+When using the warn mode, you need to specify the following parameters (which work in integer percentages):
 ```
 ram_limit=10
 cpu_limit=67

--- a/rust-server/.env.example
+++ b/rust-server/.env.example
@@ -11,12 +11,13 @@ cpu=true
 cpu_average=true
 system_uptime=true
 disk=true
-
+swap=true
 
 # Warn mode settings [IN PERCENTAGES]
 ram_limit=10
 cpu_limit=5
 disk_limit=10
+swap_limit=50
 
 
 # How often should the program run [in seconds], the higher the delay, the less system resources 

--- a/rust-server/src/logging/discord/mod.rs
+++ b/rust-server/src/logging/discord/mod.rs
@@ -35,6 +35,7 @@ pub async fn start(config: Config) {
             cpu_average: _cpu_average,
             system_uptime: _system_uptime,
             disk: _disk,
+            swap: _swap,
         } => {
             send_interval_message(
           IntervalMetrics::new(&config, &system),
@@ -49,6 +50,7 @@ pub async fn start(config: Config) {
             cpu_limit: _cpu_limit,
             ram_limit: _ram_limit,
             disk_limit: _disk_limit,
+            swap_limit: _swap_limit
         } => {
             send_warn_message(
         WarnMetrics::new(&config), 
@@ -95,6 +97,10 @@ fn load_interval_embed(embed: &mut CreateEmbed, metrics: &IntervalMetrics) {
     if metrics.ram > -1 {
         embed.field("Used RAM", format!("{} MB", metrics.ram / 1000), false);
     };
+
+    if metrics.swap > -1 {
+        embed.field("Used Swap", format!("{} MB", metrics.swap / 1000), false);
+    }
 
     if metrics.cpu > -1.0 {
         embed.field("Used CPU", format!("{}%", metrics.cpu), false);
@@ -155,7 +161,8 @@ fn load_warn_embed(embed: &mut CreateEmbed, metrics: &WarnMetrics) {
             match metric {
                 &Warn::HighCPU(cpu) => ("CPU Limit Surpassed", format!("{}%", cpu), false),
                 &Warn::HighRAM(ram) => ("RAM Limit Surpassed", format!("{}%", ram), false),
-                &Warn::HighDisk(disk) => ("Disk Limit Surpassed", format!("{}%", disk), false)
+                &Warn::HighDisk(disk) => ("Disk Limit Surpassed", format!("{}%", disk), false),
+                &Warn::HighSwap(swap) => ("Swap Limit Surpassed", format!("{}%", swap), false),
             }
         })
     );

--- a/rust-server/src/logging/discord/parsers.rs
+++ b/rust-server/src/logging/discord/parsers.rs
@@ -26,6 +26,7 @@ mod tests {
                 cpu_limit: 0,
                 ram_limit: 0,
                 disk_limit: 0,
+                swap_limit: 0,
             },
             interval: 0,
             log_type: LogType::Discord,

--- a/rust-server/src/metrics/interval.rs
+++ b/rust-server/src/metrics/interval.rs
@@ -18,6 +18,9 @@ pub struct IntervalMetrics {
 
     // Currently used disk space [In MB]
     pub disk: i64,
+
+    // Currently used Swap in KB
+    pub swap: i64,
 }
 
 
@@ -30,6 +33,7 @@ impl IntervalMetrics {
             system_uptime, 
             cpu_average,
             disk,
+            swap,
         } = config.mode {
             // Create a struct which will be filled with actual values only if the passed config has them enabled
             // -1 is used as an error (false) code.
@@ -39,6 +43,7 @@ impl IntervalMetrics {
                 system_uptime: -1,
                 cpu_average: (-1.0, -1.0, -1.0),
                 disk: -1,
+                swap: -1,
             };
         
             // Check each metric, if it is enabled, set it.
@@ -49,6 +54,8 @@ impl IntervalMetrics {
             if system_uptime { metrics.system_uptime = system.get_uptime() as i64 }
 
             if disk { metrics.disk = get_used_disk_space(system.get_disks()) }
+
+            if swap { metrics.swap = system.get_used_swap() as i64 }
 
             if cpu_average { 
                 let avg_load = system.get_load_average();
@@ -73,6 +80,8 @@ impl IntervalMetrics {
         if self.system_uptime > -1 { self.system_uptime = system.get_uptime() as i64 }
 
         if self.disk > -1 { self.disk = get_used_disk_space(system.get_disks()) }
+
+        if self.swap > -1 { self.swap = system.get_used_swap() as i64 } 
 
         if self.cpu_average.0 > -1.0 {
             let avg_load = system.get_load_average();
@@ -99,6 +108,7 @@ mod tests {
                 cpu_average: true,
                 system_uptime: true,
                 disk: true,
+                swap: true,
             },
             interval: 10,
             log_type: LogType::Discord,
@@ -115,6 +125,7 @@ mod tests {
         assert_ne!(metrics.cpu, -1.0);
         assert_ne!(metrics.cpu_average, (-1.0, -1.0, -1.0));
         assert_ne!(metrics.system_uptime, -1);
+        assert_ne!(metrics.swap, -1);
     }
 
 
@@ -127,6 +138,7 @@ mod tests {
                 cpu_limit: 20,
                 ram_limit: 20,
                 disk_limit: 20,
+                swap_limit: 15,
             },
             interval: 10,
             log_type: LogType::Discord,
@@ -150,6 +162,7 @@ mod tests {
                 cpu_average: false,
                 system_uptime: false,
                 disk: true,
+                swap: false,
             },
             interval: 10,
             log_type: LogType::Discord,
@@ -166,6 +179,7 @@ mod tests {
         assert_eq!(metrics.cpu_average, (-1.0, -1.0, -1.0));
         assert_eq!(metrics.system_uptime, -1);
         assert_ne!(metrics.disk, -1);
+        assert_eq!(metrics.swap, -1);
     }
 
 
@@ -181,6 +195,7 @@ mod tests {
                 cpu_average: false,
                 system_uptime: true,
                 disk: false,
+                swap: false,
             },
             interval: 10,
             log_type: LogType::Discord,

--- a/rust-server/src/parse_config.rs
+++ b/rust-server/src/parse_config.rs
@@ -6,12 +6,14 @@ pub enum ConfigMode {
         system_uptime: bool,
         cpu_average: bool,
         disk: bool,
+        swap: bool,
     },
 
     ConfigWarn {
         cpu_limit: u32,
         ram_limit: u32,
         disk_limit: u32,
+        swap_limit: u32,
     }
 }
 
@@ -98,12 +100,18 @@ fn get_warn_mode() -> ConfigMode {
     .parse::<u32>()
     .expect("Couldn't parse the cpu_limit to a number");
 
+    let swap_limit = std::env::var("swap_limit")
+    .expect("cpu_limit variable not specified")
+    .parse::<u32>()
+    .expect("Couldn't parse the cpu_limit to a number");
+
     if ram_limit > 100 || cpu_limit > 100 { panic!("The ram/cpu limit cannot exceed 100%") };
 
     ConfigMode::ConfigWarn {
         ram_limit,
         cpu_limit,
         disk_limit,
+        swap_limit
     }
 }
 
@@ -115,6 +123,7 @@ fn get_interval_mode() -> ConfigMode {
         cpu_average: parse_env_var_to_boolean("cpu_average"),
         system_uptime: parse_env_var_to_boolean("system_uptime"),
         disk: parse_env_var_to_boolean("disk"),
+        swap: parse_env_var_to_boolean("swap"),
     }
 }
 
@@ -167,6 +176,7 @@ mod tests {
         set_var("mode", "warn");
         set_var("ram_limit", "20");
         set_var("cpu_limit", "20");
+        set_var("swap_limit", "15");
         set_var("disk_limit", "10");
         set_var("interval", "10");
         set_var("type", "discord");
@@ -179,6 +189,7 @@ mod tests {
                 ram_limit: 20,
                 cpu_limit: 20,
                 disk_limit: 10,
+                swap_limit: 15,
             },
             interval: 10,
             log_type: LogType::Discord,
@@ -198,12 +209,14 @@ mod tests {
         set_var("ram_limit", "20");
         set_var("cpu_limit", "20");
         set_var("disk_limit", "10");
+        set_var("swap_limit", "5");
 
         let warn_mode = parse_mode();
         let test_mode = ConfigMode::ConfigWarn { 
             cpu_limit: 20,
             ram_limit: 20,
             disk_limit: 10,
+            swap_limit: 5,
         };
 
         assert_eq!(warn_mode, test_mode);
@@ -217,6 +230,7 @@ mod tests {
         set_var("ram_limit", "will not parse");
         set_var("cpu_limit", "will not parse");
         set_var("disk_limit", "will not parse");
+        set_var("swap_limit", "will not parse");
 
         parse_mode();
     }
@@ -228,6 +242,7 @@ mod tests {
         set_var("mode", "warn");
         set_var("cpu_limit", "20");
         set_var("disk_limit", "20");
+        set_var("swap_limit", "20");
         remove_var("ram_limit");
 
         parse_mode();
@@ -242,6 +257,7 @@ mod tests {
         set_var("cpu_average", "true");
         set_var("system_uptime", "true");
         set_var("disk", "true");
+        set_var("swap", "false");
 
         let interval_mode = parse_mode();
         let test_mode = ConfigMode::ConfigInterval {
@@ -250,6 +266,7 @@ mod tests {
             cpu_average: true,
             system_uptime: true,
             disk: true,
+            swap: false,
         };
 
         assert_eq!(interval_mode, test_mode);


### PR DESCRIPTION
This pull request adds the ability to log swap usage of a server.

Closes #3 